### PR TITLE
Can't dup Fixnum error fix

### DIFF
--- a/lib/gibberish/localize.rb
+++ b/lib/gibberish/localize.rb
@@ -46,7 +46,7 @@ module Gibberish
     def translate(string, key, *args)
       return if reserved_keys.include? key
       target = translations[key] || string
-      interpolate_string(target.dup, *args.dup)
+      interpolate_string(target.to_s.dup, *args.dup)
     end
 
     def load_languages!


### PR DESCRIPTION
If a language yaml file has a translation that is a number, then if Gibberish attempts to translate the matching key, it will throw an Exception when it attempts to dup the target because the translations hash is storing numeric values from the yaml as Fixnum.